### PR TITLE
Sparkowy processor liczący słowa

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/target/
+target/
 !.mvn/wrapper/maven-wrapper.jar
 
 ### STS ###

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
         <module>source</module>
         <module>processor</module>
         <module>another-processor</module>
+        <module>spark-processor</module>
         <!--<module>monitor-service</module>-->
     </modules>
 

--- a/sink/src/main/resources/application.properties
+++ b/sink/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 server.port=8081
 spring.cloud.stream.bindings.input.destination=my-proc
+spring.cloud.stream.bindings.output.consumer.header-mode=raw

--- a/source/src/main/java/pl/edu/agh/source/SourceApplication.java
+++ b/source/src/main/java/pl/edu/agh/source/SourceApplication.java
@@ -9,21 +9,35 @@ import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 
+import java.util.Random;
+import java.util.stream.Collectors;
+
 @SpringBootApplication
 @EnableBinding(Source.class)
 @EnableScheduling
 public class SourceApplication {
 
+    private static final Random random = new Random();
+    private final Source source;
+
     @Autowired
-    Source source;
+    public SourceApplication(Source source) {
+        this.source = source;
+    }
 
     public static void main(String[] args) {
         SpringApplication.run(SourceApplication.class, args);
     }
 
-    @Scheduled(fixedRate = 1000)
-    void send() {
-        source.output()
-                .send(MessageBuilder.withPayload("text").build());
+    private static String generateRandomText() {
+        return random
+                .ints(random.nextInt(1000), 'a', 'z' + 1)
+                .mapToObj(x -> String.valueOf((char) x))
+                .collect(Collectors.joining(" "));
+    }
+
+    @Scheduled(fixedRate = 100)
+    private void send() {
+        source.output().send(MessageBuilder.withPayload(generateRandomText()).build());
     }
 }

--- a/source/src/main/resources/application.properties
+++ b/source/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 server.port=8082
 spring.cloud.stream.bindings.output.destination=my-source
-spring.cloud.stream.bindings.output.contentType=application/json
+spring.cloud.stream.bindings.output.producer.header-mode=raw
+

--- a/spark-processor/README.md
+++ b/spark-processor/README.md
@@ -1,0 +1,5 @@
+# How to run
+
+```bash
+BROKERS="localhost:9092" TOPICS="my-source" mvn install exec:java
+```

--- a/spark-processor/pom.xml
+++ b/spark-processor/pom.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>stream-demo</artifactId>
+        <groupId>pl.edu.agh</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>jar</packaging>
+
+    <artifactId>spark-processor</artifactId>
+
+    <name>spark-processor</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-core_2.11</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-streaming_2.11</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-streaming-kafka-0-10_2.11</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.9.5</version>
+        </dependency>
+
+
+    </dependencies>
+
+    <build>
+        <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
+            <plugins>
+                <plugin>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>3.0.0</version>
+                </plugin>
+                <!-- see http://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_jar_packaging -->
+                <plugin>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>3.0.2</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.7.0</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.20.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.0.2</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>2.5.2</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>2.8.2</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>exec-maven-plugin</artifactId>
+                    <configuration>
+                        <mainClass>pl.edu.agh.sparkprocessor.WordCountProcessor</mainClass>
+                    </configuration>
+                </plugin>
+
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>

--- a/spark-processor/src/main/java/pl/edu/agh/sparkprocessor/WordCountProcessor.java
+++ b/spark-processor/src/main/java/pl/edu/agh/sparkprocessor/WordCountProcessor.java
@@ -1,0 +1,108 @@
+package pl.edu.agh.sparkprocessor;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.streaming.Duration;
+import org.apache.spark.streaming.Durations;
+import org.apache.spark.streaming.api.java.JavaInputDStream;
+import org.apache.spark.streaming.api.java.JavaPairDStream;
+import org.apache.spark.streaming.api.java.JavaStreamingContext;
+import org.apache.spark.streaming.kafka010.ConsumerStrategies;
+import org.apache.spark.streaming.kafka010.KafkaUtils;
+import org.apache.spark.streaming.kafka010.LocationStrategies;
+import org.codehaus.jackson.map.ObjectMapper;
+import scala.Tuple2;
+
+import java.util.*;
+
+public class WordCountProcessor {
+
+    private static final String LOG_LEVEL = "WARN";
+    private static final String RESULT_TOPIC = "my-proc";
+    private static final Duration BATCH_DURATION = Durations.seconds(5);
+
+    public static void main(String[] args) throws Exception {
+        final String brokers = getEnvOrExitWithError("BROKERS");
+        final String topics = getEnvOrExitWithError("TOPICS");
+
+        final JavaStreamingContext jssc = setupSpark("WordCountProcessor");
+        final JavaInputDStream<ConsumerRecord<String, String>> messages = createKafkaMessageStream(jssc, brokers, topics);
+
+
+        final JavaPairDStream<String, Integer> wordCounts = messages
+                .map(ConsumerRecord::value)
+                .flatMap(x -> Arrays.asList(x.split("\\s+")).iterator())
+                .mapToPair(s -> new Tuple2<>(s, 1))
+                .reduceByKey((i1, i2) -> i1 + i2);
+
+        wordCounts.foreachRDD(rdd -> {
+            String resultMessage = new ObjectMapper().writeValueAsString(rdd.collectAsMap());
+            System.out.println(resultMessage);
+
+            final Map<String, Object> kafkaParams = new HashMap<>();
+            kafkaParams.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokers);
+            kafkaParams.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+            kafkaParams.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+
+            KafkaProducer<String, String> producer = new KafkaProducer<>(kafkaParams);
+
+            producer.send(new ProducerRecord<>(RESULT_TOPIC, resultMessage));
+            producer.close();
+
+        });
+
+        jssc.start();
+        jssc.awaitTermination();
+    }
+
+    private static String getEnvOrExitWithError(String name) {
+        final String env = System.getenv(name);
+        if (env == null) {
+            System.err.println("\"" + name + "\" env must be provided");
+            System.exit(1);
+        }
+        return env;
+    }
+
+    private static JavaStreamingContext setupSpark(String appName) {
+        final SparkConf sparkConf = new SparkConf()
+                .setAppName(appName)
+                .setMaster("local[2]");
+
+        final JavaStreamingContext jssc = new JavaStreamingContext(sparkConf, BATCH_DURATION);
+        final JavaSparkContext sc = jssc.sparkContext();
+        sc.setLogLevel(LOG_LEVEL);
+
+        return jssc;
+    }
+
+    private static JavaInputDStream<ConsumerRecord<String, String>> createKafkaMessageStream(
+            JavaStreamingContext jssc,
+            String brokers,
+            String topics
+    ) {
+        final Set<String> topicsSet = new HashSet<>(Arrays.asList(topics.split(",")));
+
+        final Map<String, Object> kafkaParams = new HashMap<>();
+        kafkaParams.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, brokers);
+        kafkaParams.put(ConsumerConfig.GROUP_ID_CONFIG, "blabla");
+        kafkaParams.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        kafkaParams.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        kafkaParams.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
+        kafkaParams.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
+
+        return KafkaUtils.createDirectStream(
+                jssc,
+                LocationStrategies.PreferConsistent(),
+                ConsumerStrategies.Subscribe(topicsSet, kafkaParams)
+        );
+    }
+}
+


### PR DESCRIPTION
Działa to tak, że liczy przychodzące słowa. Wynikiem wysyłanym do modułu Sink jest JSON zawierający liczbę wystąpień danego słowa w ostatnim batchu.

Pozmieniałem spring.cloud.stream.bindings.output.*.header-mode=raw w springowych konfiguracjach, poniewaz bez tego wariowała mi kafka.

Zmieniłem trochę generator źródła, tak, żeby było widać jakieś efekty.